### PR TITLE
Fix for git command for files with white space

### DIFF
--- a/git/gitFileDifferenceAPI.js
+++ b/git/gitFileDifferenceAPI.js
@@ -25,7 +25,7 @@ async function getGitFileDifference(repoId, fileName) {
       console.log(err);
     });
 
-  const diffStat = await execPromisified(`git diff --stat ${fileName}`, {
+  const diffStat = await execPromisified(`git diff --stat "${fileName}"`, {
     cwd: repoPath,
     windowsHide: true,
   })
@@ -43,7 +43,7 @@ async function getGitFileDifference(repoId, fileName) {
     });
 
   const fileDiff = await execPromisified(
-    `git diff -U${fileContentLength} ${fileName}`,
+    `git diff -U${fileContentLength} "${fileName}"`,
     {
       cwd: repoPath,
       windowsHide: true,

--- a/git/gitRemoveStagedItems.js
+++ b/git/gitRemoveStagedItems.js
@@ -6,7 +6,7 @@ const execPromisified = util.promisify(exec);
 const fetchRepopath = require("../global/fetchGitRepoPath");
 
 const gitRemoveStagedItemApi = async (repoId, item) => {
-  return await execPromisified(`git reset ${item}`, {
+  return await execPromisified(`git reset "${item}"`, {
     cwd: fetchRepopath.getRepoPath(repoId),
     windowsHide: true,
   })

--- a/git/gitRepoStatus.js
+++ b/git/gitRepoStatus.js
@@ -224,7 +224,7 @@ const getGitStatus = async (repoPath) => {
     isGitLogAvailable &&
     (await Promise.all(
       gitTrackedFileDetails.map(async (gitFile) => {
-        return await execPromised(`git log -1 --oneline ${gitFile}`, {
+        return await execPromised(`git log -1 --oneline "${gitFile}"`, {
           cwd: repoPath,
           windowsHide: true,
         })

--- a/git/gitStageItem.js
+++ b/git/gitStageItem.js
@@ -5,7 +5,7 @@ const execPromisified = util.promisify(exec);
 const fetchRepopath = require("../global/fetchGitRepoPath");
 
 const gitStageItem = async (repoId, item) => {
-  return await execPromisified(`git add ${item}`, {
+  return await execPromisified(`git add "${item}"`, {
     cwd: fetchRepopath.getRepoPath(repoId),
     windowsHide: true,
   }).then(({ stdout, stderr }) => {


### PR DESCRIPTION
- During a staging test from windows, an issue (#14 ) was reported for a file with white space in file name. This issue has been fixed by enclosing the values in double quotes in respective git command