### PR TITLE
Git difference line feed fix

### DIFF
--- a/git/gitFetchPullApi.js
+++ b/git/gitFetchPullApi.js
@@ -44,14 +44,22 @@ const gitFetchApi = async (repoId, remoteUrl, remoteBranch) => {
     };
   }
 
-  return await execPromisified(`git fetch ${remoteName} ${remoteBranch}`, {
+  return await execPromisified(`git fetch ${remoteName} ${remoteBranch} -v`, {
     cwd: fetchRepopath.getRepoPath(repoId),
     windowsHide: true,
   })
     .then(({ stdout, stderr }) => {
       if (stdout || stderr) {
         // Git fetch alone returns the result in the standard error stream
-        const fetchResponse = stderr.trim().split("\n");
+        let responseValue = "";
+        if (stdout) {
+          responseValue += stdout;
+        }
+        if (stderr) {
+          responseValue += stderr;
+        }
+
+        const fetchResponse = responseValue.trim().split("\n");
 
         console.log("Fetch Response :" + fetchResponse);
         if (fetchResponse) {
@@ -92,13 +100,20 @@ const gitPullApi = async (repoId, remoteUrl, remoteBranch) => {
     };
   }
 
-  return await execPromisified(`git pull ${remoteName} ${remoteBranch}`, {
+  return await execPromisified(`git pull ${remoteName} ${remoteBranch} -v`, {
     cwd: fetchRepopath.getRepoPath(repoId),
     windowsHide: true,
   })
     .then(async ({ stdout, stderr }) => {
       if (stdout || stderr) {
-        const pullResponse = stderr.trim().split("\n");
+        let responseValue = "";
+        if (stdout) {
+          responseValue += stdout;
+        }
+        if (stderr) {
+          responseValue += stderr;
+        }
+        const pullResponse = responseValue.trim().split("\n");
 
         if (pullResponse && pullResponse.length > 0) {
           return {

--- a/git/gitFileDifferenceAPI.js
+++ b/git/gitFileDifferenceAPI.js
@@ -30,7 +30,7 @@ async function getGitFileDifference(repoId, fileName) {
     windowsHide: true,
   })
     .then(({ stdout, stderr }) => {
-      if (stdout && !stderr) {
+      if (stdout) {
         return stdout.trim().split("\n");
       } else {
         console.log(stderr);
@@ -50,7 +50,7 @@ async function getGitFileDifference(repoId, fileName) {
     }
   )
     .then(({ stdout, stderr }) => {
-      if (stdout && !stderr) {
+      if (stdout) {
         return stdout.trim().split("\n");
       } else {
         console.log(stderr);


### PR DESCRIPTION
- In windows, git diff API was not pulling the difference response (#16 ) due to CRLF line breaks which is routed to the stderr by child_process. The fix reads the response from both the error and response streams to check the file difference