### PR TITLE
fix to return warning message when git commit compare fails 

### DIFF
--- a/git/gitCommitCompareApi.js
+++ b/git/gitCommitCompareApi.js
@@ -13,7 +13,7 @@ async function gitCommitCompare(repoPath, baseCommit, compareCommit) {
       if (stderr) {
         console.log(stderr);
         return {
-          message: "Error occurred while fetching commit difference",
+          message: stderr,
         };
       }
 

--- a/global/gqlGlobalAPISchema.js
+++ b/global/gqlGlobalAPISchema.js
@@ -120,7 +120,7 @@ const globalAPISchema = new buildSchema(
 
         type commitCompareType{
             message: String
-            difference: [commitCompareFileType]!
+            difference: [commitCompareFileType!]
         }
 
         type compareCommitType{


### PR DESCRIPTION
git commit compare fails when the number of rename changes is high. A warning was sent back to the client when this error occurs instead of providing no hints to the user